### PR TITLE
remove the condition that is always 'true'

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/util/IndexVersion.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/IndexVersion.java
@@ -252,10 +252,6 @@ public class IndexVersion {
             return GREATER_THAN;
         } else if (firstMinor < secondMinor) {
             return LESS_THAN;
-        } else {
-            // This is an impossible scenario.
-            // This 'else' should never be triggered since we've checked for equality above already
-            return EQUAL;
         }
     }
 


### PR DESCRIPTION
I used SonarQube to scan the project and found that the condition, (firstMinor < secondMinor), will always be envaluated to true, so remove the condition  to improve the code quality.
 [https://rules.sonarsource.com/java/type/Bug/RSPEC-1145?search=true]